### PR TITLE
fix(UserSwitcher): Stop most of the logic from using entwine

### DIFF
--- a/javascript/userswitcher.js
+++ b/javascript/userswitcher.js
@@ -1,40 +1,47 @@
 (function($){
-	$.entwine('userswitcher', function($){
+	function loadSwitcher() {
+		var base = $('base').prop('href');
+		var isCMS = $('body').hasClass('cms') ? 1 : 0;
 
-		$('form.userswitcher select').entwine({
-			onchange : function(){
-				this.parents('form:first').submit();
-				this._super();
+		$.get(base + 'userswitcher/UserSwitcherFormHTML/', {userswitchercms: isCMS}).done(function(data){
+			var $data = $(data);
+			if (!$data.length) {
+				return;
+			}
+			// Submit form on change
+			$data.find('select').on('change', function() {
+				$(this.form).submit();
+			});
+			// Hide submit button
+			$data.find('.Actions').hide();
+
+			if($('body').hasClass('cms')){
+				$('.cms-login-status').append($data);
+			}else{
+				$('body').append($data);	
 			}
 		});
+	}
 
-		$('form.userswitcher .Actions').entwine({
-			onmatch : function(){
-				this.hide();
-				this._super();
-			}
-		});
-
-		$('body').entwine({
-			onmatch : function(){
-				var base = $('base').prop('href'),
-					isCMS = this.hasClass('cms') ? 1 : '';
-				
-				$.get(base + 'userswitcher/UserSwitcherFormHTML/', {userswitchercms: isCMS}).done(function(data){
-					var body = $('body');
-
-					if(body.hasClass('cms')){
-						$('.cms-login-status').append(data);
-					}else{
-						$('body').append(data);	
+	function main() {
+		var isCMS = $('body').hasClass('cms') ? 1 : 0;
+		if (!$.entwine || !isCMS) {
+			loadSwitcher();
+		} else {
+			$.entwine('userswitcher', function($){
+				$('body').entwine({
+					onmatch : function(){
+						loadSwitcher();
+						this._super();
+					},
+					onunmatch: function() {
+						this._super();
 					}
-				  	
 				});
-				this._super();
-			}
-		});
-		
-	});
+			});
+		}
+	}
+	main();
 })(jQuery);
 
  


### PR DESCRIPTION
fix(UserSwitcher): Stop most of the logic from using entwine.

This fixes https://github.com/sheadawson/silverstripe-userswitcher/issues/11.

I honestly don't know what entwine is doing, but it seemed to be buggy when the $.get function block was in the scope of the $.entwine() function.

In any case, this should retain the expected behaviour, but not bug things out.