### PR TITLE
fix(jQuery): Fixes case where you Requirements::block() jquery.js in your Page::init(), but it's not respected due to UserSwitcherControllerExtension::onAfterInit providing jquery.js on-the-fly via jquery.ondemand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ User Switching is only available to ADMIN users and only when running in dev or 
 
 * SilverStripe 3.*
 
+##Disable default jQuery
+
+If using this on the frontend, you can disable jQuery like so:
+
+```php
+Requirements::block(THIRDPARTY_DIR . '/jquery/jquery.js');
+```
+
 ##Install
 
 	$ composer require sheadawson/silverstripe-userswitcher

--- a/code/extensions/UserSwitcherControllerExtension.php
+++ b/code/extensions/UserSwitcherControllerExtension.php
@@ -14,28 +14,39 @@ class UserSwitcherControllerExtension extends Extension
 
     public function onAfterInit()
     {
-        if ($this->providUserSwitcher()) {
-            Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
-            Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
-            Requirements::javascript(FRAMEWORK_DIR  . '/javascript/jquery-ondemand/jquery.ondemand.js');
-            Requirements::javascript(USERSWITCHER    . '/javascript/userswitcher.js');
+        // NOTE: Director::is_ajax() is to avoid these files
+        //       being re-included.
+        //
+        //       Fixes case where you Requirements::block() jquery.js
+        //       in your Page::init(), but it's not respected due
+        //       to this providing jquery.js again with jquery.ondemand.
+        //
+        if (Director::is_ajax()) {
+            return;
+        }
+        
+        if ($this->provideUserSwitcher()) {
+            if ($this->owner instanceof LeftAndMain) {
+                Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
+                Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
+                Requirements::javascript(FRAMEWORK_DIR  . '/javascript/jquery-ondemand/jquery.ondemand.js');
+                Requirements::javascript(USERSWITCHER    . '/javascript/userswitcher.js');
+                Requirements::css(USERSWITCHER . '/css/userswitcher-admin.css');
+            } else {
+                Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
+                Requirements::javascript(USERSWITCHER    . '/javascript/userswitcher.js');
+                Requirements::css(USERSWITCHER . '/css/userswitcher-front.css');
+            }
         }
     }
 
     public function UserSwitcherFormHTML()
     {
-        $isCMS = substr($this->owner->getRequest()->getURL(), 0, 5) == 'admin' || (int)$this->owner->getRequest()->getVar('userswitchercms') == 1;
-
-        if ($isCMS) {
-            Requirements::css(USERSWITCHER . '/css/userswitcher-admin.css');
-        } else {
-            Requirements::css(USERSWITCHER . '/css/userswitcher-front.css');
-        }
-
+        //$isCMS = (int)$this->owner->getRequest()->getVar('userswitchercms') == 1;
         return singleton('UserSwitcherController')->UserSwitcherForm()->forTemplate();
     }
 
-    public function providUserSwitcher()
+    public function provideUserSwitcher()
     {
         return !Director::isLive() && (Permission::check('ADMIN') || Session::get('UserSwitched'));
     }

--- a/javascript/userswitcher.js
+++ b/javascript/userswitcher.js
@@ -3,7 +3,7 @@
 		var base = $('base').prop('href');
 		var isCMS = $('body').hasClass('cms') ? 1 : 0;
 
-		$.get(base + 'userswitcher/UserSwitcherFormHTML/', {userswitchercms: isCMS}).done(function(data){
+		$.get(base + 'userswitcher/UserSwitcherFormHTML/', {userswitchercms: isCMS, ajax: 1}).done(function(data){
 			var $data = $(data);
 			if (!$data.length) {
 				return;


### PR DESCRIPTION
fix(jQuery): Fixes case where you Requirements::block() jquery.js in your Page::init(), but it's not respected due to UserSwitcherControllerExtension::onAfterInit providing jquery.js on-the-fly via jquery.ondemand.

This is what would have been causing quirks on the frontend for most users I'd say. They were rolling their own jQuery and jquery.ondemand was hosing everything.